### PR TITLE
Winston logger support, issue #30

### DIFF
--- a/lib/analysis.js
+++ b/lib/analysis.js
@@ -7,12 +7,14 @@ var walk = require('acorn/dist/walk');
 var plugin = require('./tern-def-api.js');
 var scope = require('./define-path-info.js');
 var util = require('./util.js');
+var logger = require('./logger.js');
 
 require('tern/plugin/doc_comment');
 require('tern/plugin/commonjs');
 require('tern/plugin/modules');
 require('tern/plugin/node');
 require('tern/plugin/node_resolve');
+
 //require('tern/plugin/requirejs');
 
 var localDir = process.cwd();
@@ -65,13 +67,12 @@ function initTernServer(files) {
     ternServer.flush(function(err) {
         if (err) throw err;
         scope.initLocalFilesScopePaths(ternServer, localFiles);
-
         analyseAll();
     });
 
-    console.error("All ids = ", allIdents, " Undefined ids = ", undefinedIdents);
+    logger.debug("All ids = ", allIdents, " Undefined ids = ", undefinedIdents);
     if (allIdents != 0) {
-        console.error("percentage of undefined ids = ", (undefinedIdents / allIdents) * 100, "%");
+        logger.debug("percentage of undefined ids = ", (undefinedIdents / allIdents) * 100, "%");
     }
 
     return out;
@@ -92,7 +93,7 @@ function getQueryInfo(file, offset, type, start) {
         offset: offset
     }, function(error, data) {
         if (error) {
-            console.error("Error returned from Tern 'definition' request: " + error);
+            logger.error("Error returned from Tern 'definition' request: " + error);
             return;
         }
         res = data;
@@ -162,7 +163,7 @@ function getExternalRepoInfo(data) {
     var packageJson = JSON.parse(json.toString());
 
     if (packageJson.repository === undefined) {
-        console.error("PACKAGE json does not define repository ", packageJson);
+        logger.debug("PACKAGE json does not define repository ", packageJson);
         return null;
     }
 
@@ -224,7 +225,7 @@ function analyseAll() {
 
             if (data === null || pathForDef === null && data.url === undefined) {
                 undefinedIdents = undefinedIdents + 1;
-                console.error("EMPTY data for Identifier = ", node.name, "IN FILE = ", node.sourceFile.name);
+                logger.debug("EMPTY data for Identifier = ", node.name, "IN FILE = ", node.sourceFile.name);
                 return;
             }
 
@@ -253,8 +254,8 @@ function analyseAll() {
                 });
                 if (scopePathForId === null || scopePathForId === undefined) {
                     undefinedIdents = undefinedIdents + 1;
-                    console.error("SOURCE FILE = ", node.sourceFile.name);
-                    console.error("ERROR OCCURRED IN MAPPING SCOPE ID PATH", pathForId, "NAME=", node.name);
+                    logger.debug("SOURCE FILE = ", node.sourceFile.name);
+                    logger.debug("ERROR OCCURRED IN MAPPING SCOPE ID PATH", pathForId, "NAME=", node.name);
                     return;
                 }
                 var defData = {
@@ -320,11 +321,11 @@ function analyseAll() {
                     };
 
                     undefinedIdents = undefinedIdents + 1;
-                    console.error("ERROR OCCURRED IN MAPPING SCOPE DEF PATH for", pathForDef, "NAME=", node.name);
-                    console.error("SOURCE FILE = ", node.sourceFile.name);
-                    console.error("DATA = ", data);
-                    console.error("External repo = ", externalRepo);
-                    console.error("===================================");
+                    logger.debug("ERROR OCCURRED IN MAPPING SCOPE DEF PATH for", pathForDef, "NAME=", node.name);
+                    logger.debug("SOURCE FILE = ", node.sourceFile.name);
+                    logger.debug("DATA = ", data);
+                    logger.debug("External repo = ", externalRepo);
+                    logger.debug("===================================");
                     return;
                 }
                 var ref = {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,5 @@
+var winston = require('winston');
+
+winston.level = 'error';
+
+module.exports = winston;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "tern": "0.18.0",
     "acorn": "3.0.4",
     "nomnom": "1.8.1",
-    "commonjs-findpkgs": "0.0.7"
+    "commonjs-findpkgs": "0.0.7",
+    "winston": "2.2.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Winston support was added. Level of logging is set into 'error'. To see statistics messages and some info about unresolved ids please set logging level into 'debug'. 
P.S Also I need to change logging for .bin/srclib-javascript file - will be done together with refactoring of 'scan' command