### PR TITLE
Coverage fixes

### DIFF
--- a/lib/type-format.js
+++ b/lib/type-format.js
@@ -49,7 +49,7 @@ function simplifyFunctions(type) {
   /**
    * Removes nested function type signatures
    * Function type fn(param1: type1, param2: type2) -> type is transformed into (param1, param2) -> type
-  */
+   */
   function removeParameterFn(type) {
     var res = XRegExp.matchRecursive(type, "fn\\(", "\\)", 'g');
     var resType = type;
@@ -60,23 +60,28 @@ function simplifyFunctions(type) {
   }
 
   // returns all occurences of functions, takes into account nested functions
-  var res = XRegExp.matchRecursive(type, "fn\\(", "\\)", 'g');
-  var resType = type;
+  try {
+    var res = XRegExp.matchRecursive(type, "fn\\(", "\\)", 'g');
+    var resType = type;
 
-  for (var i = 0; i < res.length; i++) {
-     //removes nested functions
-    var fnSig = removeParameterFn(res[i]);
-    var paramsRes = fnSig.split(",");
-    var paramNames = [];
-    //removes types of parameters
-    for (var j = 0; j < paramsRes.length; j++) {
-      var param = paramsRes[j];
-      paramNames.push(param.split(":")[0]);
+    for (var i = 0; i < res.length; i++) {
+      //removes nested functions
+      var fnSig = removeParameterFn(res[i]);
+      var paramsRes = fnSig.split(",");
+      var paramNames = [];
+      //removes types of parameters
+      for (var j = 0; j < paramsRes.length; j++) {
+        var param = paramsRes[j];
+        paramNames.push(param.split(":")[0]);
+      }
+      var newFnSig = paramNames.join(", ");
+      resType = resType.replace("fn(" + res[i] + ")", "(" + newFnSig + ")");
     }
-    var newFnSig = paramNames.join(", ");
-    resType = resType.replace("fn(" + res[i] + ")", "(" + newFnSig + ")");
-  }
 
-  return resType;
+    return resType;
+  } catch (exc) {
+    logger.debug("Error with Xregexp match for type = ", type, "Exception = ", exc);
+    return type;
+  }
 }
 

--- a/lib/type-format.js
+++ b/lib/type-format.js
@@ -81,7 +81,7 @@ function simplifyFunctions(type) {
 
     return resType;
   } catch (exc) {
-    logger.debug("Error with Xregexp match for type = ", type, "Exception = ", exc);
+    logger.error("Error with Xregexp match for type = ", type, "Exception = ", exc);
     return type;
   }
 }

--- a/lib/type-format.js
+++ b/lib/type-format.js
@@ -1,5 +1,6 @@
 //XRegExp lib provided functions for search and work with nested regexp
 var XRegExp = require('xregexp');
+var logger = require('./logger.js');
 
 /**
  * Main function for type formatting, replaces functions and objects,


### PR DESCRIPTION
Add catching exception from XRegExp library. It is used for type format simplification. Fix for javascript projects: github.com/koajs/koa, github.com/ajaxorg/ace, github.com/adobe/brackets