### PR TITLE
Fix for some projects with unusual node_modules structure

### DIFF
--- a/lib/analysis.js
+++ b/lib/analysis.js
@@ -186,10 +186,28 @@ function getExternalRepoInfo(data) {
     if (pos < 0 || pos > 0 && filePath.charAt(pos - 1) != "/") {
         return null;
     }
+
     var prefix = filePath.substring(0, pos);
     var suffix = filePath.substring(pos + "node_modules/".length);
+
     var pathRes = suffix.split("/");
-    var packageJsonPath = path.join(prefix,  "node_modules", pathRes[0], "package.json");
+    var dirPath = path.join(prefix,  "node_modules", pathRes[0]);
+
+    var packageJsonPath = "";
+    if (fs.lstatSync(dirPath).isDirectory()) {
+        packageJsonPath = path.join(prefix, "node_modules", pathRes[0], "package.json");
+    } else {
+        packageJsonPath = path.join(prefix, "node_modules", "package.json");
+    }
+
+
+    //check whether package.json file exists in the determined directory
+    try {
+        fs.statSync(packageJsonPath);
+    } catch (e) {
+        return null;
+    }
+
     var json = fs.readFileSync(packageJsonPath);
     var packageJson = JSON.parse(json.toString());
 
@@ -394,7 +412,6 @@ function analyseAll() {
             }
         }
     });
-
 
     ternServer.files.forEach(function(file) {
         if (file.name.indexOf('node_modules') == -1) {

--- a/lib/analysis.js
+++ b/lib/analysis.js
@@ -193,15 +193,14 @@ function getExternalRepoInfo(data) {
     var pathRes = suffix.split("/");
     var dirPath = path.join(prefix,  "node_modules", pathRes[0]);
 
-    var packageJsonPath = "";
+    //checking whether path contains directory after node_modules
     if (fs.lstatSync(dirPath).isDirectory()) {
-        packageJsonPath = path.join(prefix, "node_modules", pathRes[0], "package.json");
+        var packageJsonPath = path.join(prefix, "node_modules", pathRes[0], "package.json");
     } else {
-        packageJsonPath = path.join(prefix, "node_modules", "package.json");
+        var packageJsonPath = path.join(prefix, "node_modules", "package.json");
     }
 
-
-    //check whether package.json file exists in the determined directory
+    //check whether package.json file exists in the determined path
     try {
         fs.statSync(packageJsonPath);
     } catch (e) {


### PR DESCRIPTION
There are some projects with folder node_modules which does not have submodules with external libs, but only javascript files inside it. Package.json file can be also absent.