### PR TITLE
Fix issue with type format caused by inproper return type from tern

### DIFF
--- a/lib/type-format.js
+++ b/lib/type-format.js
@@ -82,7 +82,7 @@ function simplifyFunctions(type) {
 
     return resType;
   } catch (exc) {
-    logger.error("Error with Xregexp match for type = ", type, ", Exception = ", exc);
+    logger.error("Error with Xregexp match, failed to format type = ", type, ", Exception = ", exc);
     return type;
   }
 }

--- a/lib/type-format.js
+++ b/lib/type-format.js
@@ -47,6 +47,7 @@ function simplifyObjects(type) {
  * Simplifies function types, deletes types of parameters
  */
 function simplifyFunctions(type) {
+  type = type.replace("fn*(", "fn(");
   /**
    * Removes nested function type signatures
    * Function type fn(param1: type1, param2: type2) -> type is transformed into (param1, param2) -> type
@@ -81,7 +82,7 @@ function simplifyFunctions(type) {
 
     return resType;
   } catch (exc) {
-    logger.error("Error with Xregexp match for type = ", type, "Exception = ", exc);
+    logger.error("Error with Xregexp match for type = ", type, ", Exception = ", exc);
     return type;
   }
 }


### PR DESCRIPTION
There was return type in the next format - fn*(param1, param2, ...), instead of just fn(param1, param2, ...). In this case XregExp lib throws an exception. Minor fix to replace '*' in type format was provided.